### PR TITLE
Bump github.com/jub0bs/cors from 0.1.2 to 0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	connectrpc.com/cors v0.1.0
 	connectrpc.com/grpcreflect v1.2.0
 	github.com/jba/templatecheck v0.7.0
-	github.com/jub0bs/cors v0.1.2
+	github.com/jub0bs/cors v0.1.3
 	github.com/oklog/ulid/v2 v2.1.0
 	go.akshayshah.org/attest v1.0.2
 	golang.org/x/net v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM
 github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
 github.com/jba/templatecheck v0.7.0 h1:wjTb/VhGgSFeim5zjWVePBdaMo28X74bGLSABZV+zIA=
 github.com/jba/templatecheck v0.7.0/go.mod h1:n1Etw+Rrw1mDDD8dDRsEKTwMZsJ98EkktgNJC6wLUGo=
-github.com/jub0bs/cors v0.1.2 h1:9K3xVQHfu/WGLDqmQoj0Cw8bEXAezSeFjmdrRu5iK5E=
-github.com/jub0bs/cors v0.1.2/go.mod h1:l9xvVpLCwvnE6HPIbfq7wDgEfKLJjCZbvA3M+Wp4QhM=
+github.com/jub0bs/cors v0.1.3 h1:3Bd3rmi8wb71g5RIzC9bSZ4RncfdcENLZ/DsqVgzZWQ=
+github.com/jub0bs/cors v0.1.3/go.mod h1:tIG7tNkQ9A1wJ4CLvf8v909VI/5fnSBU49O5Mwwvb1k=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=


### PR DESCRIPTION
There is a critical vulnerability in v0.1.2; see https://github.com/jub0bs/cors/security/advisories/GHSA-vhxv-fg4m-p2w8.